### PR TITLE
Keep TFB path hints that fail the gossip stone reachability check

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -215,6 +215,15 @@ def add_hint(spoiler: Spoiler, world: World, groups: list[list[int]], gossip_tex
     first = True
     success = True
 
+    # Disable the reachability requirement for TFB path hints, for the same reason it is disabled
+    # below: we would rather place a hint the player can't read yet than not place it at all.
+    # The hint functions mark their location as hinted before placement is attempted, so a failure
+    # here permanently consumes a path location without hinting it. As the pool of free stones
+    # shrinks, the odds that every remaining stone sits behind the hinted item grow, and the leftover
+    # stones then get filled with echo hints of paths that were already hinted. Echo hints ignore
+    # reachability entirely, so enforcing it here only loses information.
+    ignore_reachability = world.settings.triforce_blitz and hint_type in ('goal-legacy', 'goal-legacy-single')
+
     # Prevent randomizer from placing hint in removed locations for this hint type
     if 'remove_stones' in world.hint_dist_user['distribution'][hint_type]:
         removed_stones = world.hint_dist_user['distribution'][hint_type]['remove_stones']
@@ -253,7 +262,7 @@ def add_hint(spoiler: Spoiler, world: World, groups: list[list[int]], gossip_tex
                 stone_locations = [world.get_location(stone_name) for stone_name in stone_names]
 
                 reachable = True
-                if locations:
+                if locations and not ignore_reachability:
                     for location in locations:
                         if not any(map(lambda stone_location: can_reach_hint(spoiler.worlds, stone_location, location), stone_locations)):
                             reachable = False


### PR DESCRIPTION
Fixes a long-standing TFB complaint: echo hints showing up on gossip stones while path items are still unhinted.

`get_goal_legacy_hint` marks its chosen location as hinted *before* `add_hint` attempts placement, and `add_hint` requires the first copy of a hint to land on a stone that is reachable with the hinted item removed. When no free stone group satisfies that, placement fails and the hint type is requeued — but the path location stays marked as hinted, so it is silently dropped and never hinted by anything.

Three things make this land on the worst possible candidates:

- The free stone pool shrinks as hints are placed, so the last path hints have only 2–4 groups left to satisfy the check.
- `prioritize_dungeons` defers overworld path locations to the end, and those tend to hold the early world-gating items (Kokiri Sword, Bow, Bomb Bag) most likely to cut off every remaining stone.
- The hint shop filter further deprioritizes locations already covered by a shop hint.

Once every path location has been consumed, `goal-legacy` returns `None`, and the leftover stones get filled by `echo` (next in the fixed order) repeating paths that were already hinted.

The fix skips the reachability check for TFB path hints. This matches the reasoning already applied to the hint lock rule immediately below it:

> Disable this logic for TFB. It is better for our gameplay to place inaccessible hints instead of not placing a hint that otherwise would exist.

…and it matches `get_echo_hint`, which passes no locations precisely because "we don't care about reachability at all." Before this change the generator would refuse to put a real path hint on a stone and then put an echo of that same path on that exact stone.

## Testing

Two reported seeds reproduced bit-exactly (matching file hashes) and confirmed fixed:

| Seed | Before | After |
| --- | --- | --- |
| `641e885e-9988-4ee8-8e1d-5d2150f7f7bd` (S5 Co-op, blitz-111) | 9 path hints, `HC GS Tree` (path Bow) dropped, 2 echoes | 10 path hints, 0 echoes |
| `bbfa2c4d-71e1-494c-b1a4-023133c004a2` (S5, blitz-115) | 9 path hints, `LW Ocarina Memory Game` (path Kokiri Sword) and `LW Target in Woods` (path Bomb Bag) dropped, 2 echoes | 10 path hints, 0 echoes |

For the older seed the two-line change was backported onto the `v9.0.1-blitz-1.11` tag so the comparison was against the exact world that was played.

Generator debug output for the second seed, before:

```
Placed goal-legacy hint for SFM Wolfos Grotto Chest.
Failed to place goal-legacy fixed hint for LW Ocarina Memory Game.
Failed to place goal-legacy fixed hint for LW Target in Woods.
Placed goal-legacy hint for LW Near Shortcuts Grotto Chest.
Placed echo hint.
Placed echo hint.
```

Instrumenting `add_hint` confirmed the cause was the reachability gate rather than a stone shortage — four groups were still free:

```
goal-legacy attempt for ['LW Ocarina Memory Game']; 4 groups left
  stone ['Colossus Gossip Stone'] NOT reachable without Kokiri Sword @ LW Ocarina Memory Game
  stone ['Dodongos Cavern Gossip Stone'] NOT reachable without Kokiri Sword ...
  stone ['DMT Storms Grotto Gossip Stone'] NOT reachable without Kokiri Sword ...
  stone ['GC Maze Gossip Stone'] NOT reachable without Kokiri Sword ...
```

**Regression check:** 20 paired generations (10 seeds × `triforce-blitz-s5` and `triforce-blitz-s5-coop`) against stock and patched HEAD. All 20 pairs produced identical path-hint, echo, and failed-placement counts, and no errors — the gate only changed the outcome in the cases where it was eating a hint. Seeds with genuinely short path lists still produce echoes as intended.

No in-game testing; this only affects which text goes on which gossip stone.

## Notes

- No version bump included, per the usual separate-commit convention. This does change hint output, so it needs one before release.
- `unlock-woth`, `woth`, and `goal` mark their locations the same way and can be dropped by the same mechanism. Left alone here to keep this scoped to what was measured. A general "don't consume the location on failed placement" fix needs care, since the burn is currently what stops `fixed_hint_types.insert(0, hint_type)` from retrying the same unplaceable location forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
