### PR TITLE
Verify the Triforce Blitz win condition in spoiler tests

### DIFF
--- a/Unittest.py
+++ b/Unittest.py
@@ -18,7 +18,7 @@ from EntranceShuffle import EntranceShuffleError
 from Fill import ShuffleError
 from Hints import HintArea, build_misc_item_hints
 from Item import ItemInfo
-from ItemPool import remove_junk_items, remove_junk_ludicrous_items, ludicrous_items_base, ludicrous_items_extended, trade_items, ludicrous_exclusions
+from ItemPool import remove_junk_items, remove_junk_ludicrous_items, ludicrous_items_base, ludicrous_items_extended, trade_items, ludicrous_exclusions, triforce_blitz_items
 from LocationList import location_is_viewable
 from Main import main, resolve_settings, build_world_graphs
 from Messages import Message, read_messages, shuffle_messages
@@ -855,7 +855,18 @@ class TestValidSpoilers(unittest.TestCase):
         locations, items, locitems = self.loc_item_collection(pl)
         self.required_checks(spoiler, locations, items, locitems)
         # Everybody reached the win condition in the playthrough
-        if spoiler['settings'].get('triforce_hunt', False) or spoiler['randomized_settings'].get('triforce_hunt', False):
+        if spoiler['settings'].get('triforce_blitz', False) or spoiler['randomized_settings'].get('triforce_blitz', False):
+            # Triforce Blitz is won by collecting the three named Triforce pieces rather than
+            # by reaching Ganon. Each world normally owns one of each; take the counts from the
+            # item pool so a piece given as a starting item (no location to appear at) still works.
+            item_pool = self.normalize_worlds_dict(spoiler['item_pool'])
+            self.assertEqual(
+                {p: {piece: item_pool[p].get(piece, 0) for piece in triforce_blitz_items}
+                    for p in items},
+                {p: {piece: c[piece] for piece in triforce_blitz_items}
+                    for p, c in items.items()},
+                'Playthrough missing some (or having extra) Triforce Blitz pieces')
+        elif spoiler['settings'].get('triforce_hunt', False) or spoiler['randomized_settings'].get('triforce_hunt', False):
             item_pool = self.normalize_worlds_dict(spoiler['item_pool'])
             # playthrough assumes each player gets exactly the goal
             req = spoiler['settings'].get('triforce_goal_per_world', None) or spoiler['randomized_settings'].get('triforce_goal_per_world', None)


### PR DESCRIPTION
`TestValidSpoilers.test_presets` has been failing on **all nine** Triforce Blitz presets, which means the fork has had no working spoiler validation on its own presets at all.

`verify_playthrough` branches on `triforce_hunt` and otherwise falls through to asserting that the playthrough contains exactly one item literally named `Triforce` — the item you get for beating Ganon. Triforce Blitz sets `triforce_blitz` instead and is won by collecting the Triforce of Power, Wisdom and Courage, so that count is legitimately always 0:

```
AssertionError: {1: 1} != {1: 0} : Playthrough missing some (or having extra) Triforces
```

The seeds were fine; the assertion simply didn't know about the mode. `Unittest.py` had never been adapted for Triforce Blitz.

This adds a `triforce_blitz` branch that checks each world collected its three named pieces. Two notes on the implementation:

* Expected counts come from `spoiler['item_pool']` rather than being hardcoded to 1, so a piece handed out as a starting item — no location to appear at — still verifies. This matches how the neighbouring `triforce_hunt` branch already works.
* `triforce_blitz_items` is imported from `ItemPool` rather than duplicated as a literal, so the test tracks the same source of truth the fill and hint code use.

## Testing

`TestValidSpoilers` goes from `FAILED (failures=9, skipped=1)` to **`OK (skipped=1)`**. The remaining skip is the pre-existing hell-mode entrance shuffle skip, unchanged.

Ground truth was established before writing the assertion rather than guessed at: running the test's own `loc_item_collection` over all nine generated Triforce Blitz spoilers showed every player holding exactly one each of Power/Wisdom/Courage, with `Triforce Piece` and `Triforce` both 0. That includes both co-op presets, where `duality` linking places pieces in the other world's locations but each world still owns one of each, and the spoiler's `player` field attributes them correctly.

Running the real `verify_woth` / `verify_playthrough` / `verify_disables` over all **22** generated preset spoilers gives 0 failures, so the nine Triforce Blitz presets pass and the 13 non-Triforce-Blitz ones are unaffected by the new branch.

Since a test that cannot fail is worthless, the assertion was mutation-tested rather than only checked for passing:

| Mutation | Single-world | Co-op |
| --- | --- | --- |
| unmodified | passes | passes |
| drop a Triforce of Wisdom from the playthrough | caught | caught, attributed to player 2 |
| add a duplicate Triforce of Power | caught | caught |

No plando fixture in `tests/plando/` enables `triforce_blitz` (none of the 162), so `test_presets` is the only caller exercising this path and asserting strictly is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
